### PR TITLE
Switch git push default to simple

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -25,7 +25,7 @@
 [merge]
 	summary = true
 [push]
-	default = current
+	default = simple
 [rebase]
 	autosquash = true
 [include]


### PR DESCRIPTION
It removes the following git warning:

```
warning: push.default is unset; its implicit value is changing in
Git 2.0 from 'matching' to 'simple'. To squelch this message
and maintain the current behavior after the default changes, use:

  git config --global push.default matching

To squelch this message and adopt the new behavior now, use:

  git config --global push.default simple
```
