### PR TITLE
Rebase by default when doing git pull

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -12,8 +12,6 @@
 	rmbranch = "!f(){ git branch -d ${1} && git push origin --delete ${1}; };f"
 	la = "!git config -l | grep alias | cut -c 7-"
 	wip = !git add -A && git commit -m 'WIP'
-[branch]
-	autosetuprebase = always
 [color]
 	ui = auto
 [core]
@@ -26,6 +24,8 @@
 	summary = true
 [push]
 	default = simple
+[pull]
+	rebase = true
 [rebase]
 	autosquash = true
 [include]


### PR DESCRIPTION
remove `branch.autosetuprebase = always` as it is compatible with Git < 1.7.9
