### PR TITLE
Add vim-trailing-whitespace

### DIFF
--- a/bundles.vim
+++ b/bundles.vim
@@ -157,3 +157,7 @@ Plugin 'isRuslan/vim-es6'
 Plugin 'kylef/apiblueprint.vim'
 " Syntax highlighting and linting for API Blueprint
 " https://github.com/kylef/apiblueprint.vim
+
+Plugin 'bronson/vim-trailing-whitespace'
+" Highlights trailing whitespace in red and provides :FixWhitespace to fix it.
+" https://github.com/bronson/vim-trailing-whitespace


### PR DESCRIPTION
Highlights trailing whitespace in **red**.

![screenshot](https://cloud.githubusercontent.com/assets/2790520/19539409/e7990f14-961e-11e6-832d-163a0c562035.png)
