### PR TITLE
Turn off ZSH nomatch option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -7,6 +7,9 @@ ZSH_THEME="gallois"
 # Note: zsh-syntax-highlighting needs to be the last element of the array
 plugins=(git ruby rails autojump history-substring-search zsh-syntax-highlighting)
 
+# Allow [, ],or ?
+unsetopt nomatch
+
 source $HOME/.aliases
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
**Background**

When running the following command in zsh:

```sh
$ rake tweets:send[cpytel]
```

We will get the following error:

```sh
# zsh: no matches found: tweets:send[cpytel]
```

This change fixes the error, so we are able to type `[`, `]`, or `?`